### PR TITLE
Fix syntax highlighter import

### DIFF
--- a/src/components/AiResponse.jsx
+++ b/src/components/AiResponse.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { hopscotch, coy } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { hopscotch, coy } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { useState, useEffect, useCallback } from 'react';
 
 /**

--- a/src/lib/appwrite.js
+++ b/src/lib/appwrite.js
@@ -2,6 +2,7 @@
 /**
  * Node modules
  */
+/* global process */
 import { Client, Account, Avatars, Databases } from 'appwrite';
 
 /**

--- a/src/lib/googleAi.js
+++ b/src/lib/googleAi.js
@@ -2,6 +2,7 @@
 /**
  * Node modules
  */
+/* global process */
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
 const genAI = new GoogleGenerativeAI(process.env.NEXT_PUBLIC_GEMINI_API_KEY);


### PR DESCRIPTION
## Summary
- import syntax highlighter styles from cjs bundle
- declare `process` as global in appwrite and google AI helpers

## Testing
- `npm run lint`
- `npm run build` *(fails: className prop in Layout.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_683f61f3e7b88333855c9105c4ed1772